### PR TITLE
Add in buttons to remove DataOutputModal element after it has been opened, test and add basic CSS alignments

### DIFF
--- a/src/containers/DataOutputModal/DataOutputModal.css
+++ b/src/containers/DataOutputModal/DataOutputModal.css
@@ -1,0 +1,6 @@
+.data-output-modal {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}

--- a/src/containers/DataOutputModal/DataOutputModal.test.js
+++ b/src/containers/DataOutputModal/DataOutputModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DataOutputModal, mapStateToProps } from './';
+import { DataOutputModal, mapStateToProps, mapDispatchToProps } from './';
 import { shallow } from 'enzyme';
 
 describe('DataOutputModal', () => {
@@ -29,4 +29,18 @@ describe('mapStateToProps function', () => {
     expect(mappedProps).toEqual(expected)
   });
 
+});
+
+describe('mapDispatchToProps function', () => {
+  let mockDispatch = jest.fn();
+  let mappedProps;
+
+  beforeEach(() => {
+    mappedProps = mapDispatchToProps(mockDispatch)
+  });
+
+  it('should call dispatch when setSelectedModal is called', () => {
+    mappedProps.setSelectedModal()
+    expect(mockDispatch).toHaveBeenCalled();
+  });
 });

--- a/src/containers/DataOutputModal/index.js
+++ b/src/containers/DataOutputModal/index.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import './DataOutputModal.css';
 import { connect } from 'react-redux';
+import { setSelectedModal } from '../../Actions/selection-actions';
 
 export class DataOutputModal extends Component {
   // constructor(props) {
@@ -8,11 +9,14 @@ export class DataOutputModal extends Component {
   // }
 
   render() {
-    let { selectedModal } = this.props
+    let { selectedModal, setSelectedModal } = this.props
 
     return(
-      <div>
+      <div className='data-output-modal'>
         <h1>{selectedModal}!</h1>
+        <button
+          onClick={() => setSelectedModal()}
+        >X</button>
       </div>
     )
   }
@@ -22,4 +26,8 @@ export const mapStateToProps = (state) => ({
   selectedModal: state.selectedModal
 })
 
-export default connect(mapStateToProps)(DataOutputModal)
+export const mapDispatchToProps = (dispatch) => ({
+  setSelectedModal: () => dispatch(setSelectedModal(''))
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(DataOutputModal)


### PR DESCRIPTION
## Description:
Added buttons to close the DataOutputModal elements after they have been opened, tested and added basic CSS alignments

This pull request addresses issue #`14`.